### PR TITLE
Edited defaults/initrd.defaults via GitHub to fix booting with Kernel-3.0

### DIFF
--- a/defaults/initrd.defaults
+++ b/defaults/initrd.defaults
@@ -50,6 +50,7 @@ KMINOR=`echo $KV | cut -f2 -d.`
 KVER="${KMAJOR}.${KMINOR}"
 MISCOPTS='debug detect'
 
+<<<<<<< HEAD
 if [ "${KMAJOR}" -eq 2 -a "${KMINOR}" -ge '6' ] || [ "${KMAJOR}" -gt 2 ]
 then
 	KV_2_6_OR_GREATER="yes"

--- a/genkernel
+++ b/genkernel
@@ -2,7 +2,7 @@
 # $Id$
 
 PATH="${PATH}:/sbin:/usr/sbin"
-GK_V='3.4.15-r2-funtoo'
+GK_V='3.4.15-r4-funtoo'
 
 # Set the default for TMPDIR.  May be modified by genkernel.conf or the
 # --tempdir command line option.


### PR DESCRIPTION
Edited defaults/initrd.defaults via GitHub to fix booting with Kernel-3.0 or greater
