### PR TITLE
Ported support for kernel 3.0 from http://git.overlays.gentoo.org/gitweb/

### DIFF
--- a/defaults/initrd.defaults
+++ b/defaults/initrd.defaults
@@ -50,7 +50,7 @@ KMINOR=`echo $KV | cut -f2 -d.`
 KVER="${KMAJOR}.${KMINOR}"
 MISCOPTS='debug detect'
 
-if [ "${KMAJOR}" -eq 2 -a "${KMINOR}" -ge '6' ]
+if [ "${KMAJOR}" -ge 3 ] || [ "${KMAJOR}" -eq 2 -a "${KMINOR}" -eq '6' ]
 then
 	KV_2_6_OR_GREATER="yes"
 fi
@@ -59,7 +59,7 @@ QUIET='1'
 ROOT_LINKS='bin sbin lib lib32 lib64 boot usr opt emul'
 ROOT_TREES='etc root home var'
 INSMOD='insmod'
-if [ "${KMINOR}" -gt '4' ]
+if [ "${KMAJOR}" -ge 3 ] || [ "${KMAJOR}" -eq 2 -a "${KMINOR}" -gt '4' ]
 then
 	KSUFF='.ko'
 else


### PR DESCRIPTION
Ported support for kernel 3.0 from http://git.overlays.gentoo.org/gitweb/?p=proj/genkernel.git;a=commit;h=6b92c54c1ecc90735f101fafab65d993938d8ee6
