### PR TITLE
Fix libgcc_s.so.1 not being found by zfs tools

### DIFF
--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -317,6 +317,7 @@ append_zfs(){
 
 	copy_binaries "${TEMP}/initramfs-zfs-temp" /sbin/{mount.zfs,zdb,zfs,zpool} ${libgccpath}
 	cd "${TEMP}/initramfs-zfs-temp/lib"
+	ln -s ${libgccpath} libgcc_s.so.1
 	append_to_cpio "${TEMP}/initramfs-zfs-temp/"
 }
 


### PR DESCRIPTION
None of (zpool, zfs, zdb) are able to execute at boot time without this.